### PR TITLE
Make sqlite3_open_v2 a requirement

### DIFF
--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -43,13 +43,9 @@ static VALUE sqlite3_rb_close(VALUE self);
 static VALUE initialize(int argc, VALUE *argv, VALUE self)
 {
   sqlite3RubyPtr ctx;
-  VALUE file;
-  VALUE opts;
-  VALUE zvfs;
   VALUE flags;
 #ifdef HAVE_SQLITE3_OPEN_V2
   int mode = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
-#endif
   int status;
 
   Data_Get_Struct(self, sqlite3Ruby, ctx);
@@ -86,46 +82,27 @@ static VALUE initialize(int argc, VALUE *argv, VALUE self)
        * SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE -- always used for sqlite3_open and sqlite3_open16
        */
       if (Qtrue == rb_hash_aref(opts, ID2SYM(rb_intern("readonly")))) {
-#ifdef HAVE_SQLITE3_OPEN_V2
         mode = SQLITE_OPEN_READONLY;
-#else
-        rb_raise(rb_eNotImpError, "sqlite3-ruby was compiled against a version of sqlite that does not support readonly databases");
-#endif
       }
       if (Qtrue == rb_hash_aref(opts, ID2SYM(rb_intern("readwrite")))) {
-#ifdef HAVE_SQLITE3_OPEN_V2
         if (mode == SQLITE_OPEN_READONLY) {
             rb_raise(rb_eRuntimeError, "conflicting options: readonly and readwrite");
         }
         mode = SQLITE_OPEN_READWRITE;
-#else
-        rb_raise(rb_eNotImpError, "sqlite3-ruby was compiled against a version of sqlite that does not support readwrite without create");
-#endif
       }
       flags = rb_hash_aref(opts, ID2SYM(rb_intern("flags")));
       if (flags != Qnil) {
-#ifdef HAVE_SQLITE3_OPEN_V2
         if ((mode & SQLITE_OPEN_CREATE) == 0) {
             rb_raise(rb_eRuntimeError, "conflicting options: flags with readonly and/or readwrite");
         }
         mode = (int)NUM2INT(flags);
-#else
-        rb_raise(rb_eNotImpError, "sqlite3-ruby was compiled against a version of sqlite that does not support flags on open");
-#endif
       }
-#ifdef HAVE_SQLITE3_OPEN_V2
       status = sqlite3_open_v2(
           StringValuePtr(file),
           &ctx->db,
           mode,
           NIL_P(zvfs) ? NULL : StringValuePtr(zvfs)
       );
-#else
-      status = sqlite3_open(
-          StringValuePtr(file),
-          &ctx->db
-      );
-#endif
     }
 
 #ifdef HAVE_RUBY_ENCODING_H
@@ -134,6 +111,7 @@ static VALUE initialize(int argc, VALUE *argv, VALUE self)
 
   CHECK(ctx->db, status)
 
+<<<<<<< HEAD
   rb_iv_set(self, "@tracefunc", Qnil);
   rb_iv_set(self, "@authorizer", Qnil);
   rb_iv_set(self, "@encoding", Qnil);
@@ -143,10 +121,9 @@ static VALUE initialize(int argc, VALUE *argv, VALUE self)
   rb_iv_set(self, "@results_as_hash", rb_hash_aref(opts, sym_results_as_hash));
   rb_iv_set(self, "@type_translation", rb_hash_aref(opts, sym_type_translation));
 #ifdef HAVE_SQLITE3_OPEN_V2
+=======
+>>>>>>> 31dfc72... Make sqlite3_open_v2 a requirement
   rb_iv_set(self, "@readonly", (mode & SQLITE_OPEN_READONLY) ? Qtrue : Qfalse);
-#else
-  rb_iv_set(self, "@readonly", Qfalse);
-#endif
 
   if(rb_block_given_p()) {
     rb_ensure(rb_yield, self, sqlite3_rb_close, self);

--- a/ext/sqlite3/extconf.rb
+++ b/ext/sqlite3/extconf.rb
@@ -25,7 +25,11 @@ have_func('sqlite3_backup_init')
 have_func('sqlite3_column_database_name')
 have_func('sqlite3_enable_load_extension')
 have_func('sqlite3_load_extension')
-have_func('sqlite3_open_v2')
+
+unless have_func('sqlite3_open_v2')
+  abort "Please use a newer version of SQLite3"
+end
+
 have_func('sqlite3_prepare_v2')
 have_type('sqlite3_int64', 'sqlite3.h')
 have_type('sqlite3_uint64', 'sqlite3.h')


### PR DESCRIPTION
I don't want to support SQLite3 so old it doesn't have that function.

(cherry picked from commit 31dfc7206a6a1e0fa3304a51540d7a7cf9d729a4)