### PR TITLE
Remove rb_scan_args

### DIFF
--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -32,20 +32,10 @@ utf16_string_value_ptr(VALUE str)
 
 static VALUE sqlite3_rb_close(VALUE self);
 
-/* call-seq: SQLite3::Database.new(file, options = {})
- *
- * Create a new Database object that opens the given file. If utf16
- * is +true+, the filename is interpreted as a UTF-16 encoded string.
- *
- * By default, the new database will return result rows as arrays
- * (#results_as_hash) and has type translation disabled (#type_translation=).
- */
-static VALUE initialize(int argc, VALUE *argv, VALUE self)
+static VALUE init_internals(VALUE self, VALUE file, VALUE opts, VALUE zvfs)
 {
   sqlite3RubyPtr ctx;
-  VALUE file;
-  VALUE opts;
-  VALUE zvfs;
+#ifdef HAVE_SQLITE3_OPEN_V2
   VALUE flags;
 #ifdef HAVE_SQLITE3_OPEN_V2
   int mode = SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE;
@@ -54,7 +44,6 @@ static VALUE initialize(int argc, VALUE *argv, VALUE self)
 
   Data_Get_Struct(self, sqlite3Ruby, ctx);
 
-  rb_scan_args(argc, argv, "12", &file, &opts, &zvfs);
 #if defined StringValueCStr
   StringValuePtr(file);
   rb_check_safe_obj(file);
@@ -849,7 +838,11 @@ void init_sqlite3_database()
   cSqlite3Database = rb_define_class_under(mSqlite3, "Database", rb_cObject);
 
   rb_define_alloc_func(cSqlite3Database, allocate);
+<<<<<<< HEAD
   rb_define_method(cSqlite3Database, "initialize", initialize, -1);
+=======
+  rb_define_private_method(cSqlite3Database, "init_internals", init_internals, 3);
+>>>>>>> a4d5034... Remove rb_scan_args
   rb_define_method(cSqlite3Database, "collation", collation, 2);
   rb_define_method(cSqlite3Database, "close", sqlite3_rb_close, 0);
   rb_define_method(cSqlite3Database, "closed?", closed_p, 0);

--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -50,6 +50,35 @@ module SQLite3
 
     end
 
+    # call-seq: SQLite3::Database.new(file, options = {})
+    #
+    # Create a new Database object that opens the given file. If utf16
+    # is +true+, the filename is interpreted as a UTF-16 encoded string.
+    #
+    # By default, the new database will return result rows as arrays
+    # (#results_as_hash) and has type translation disabled (#type_translation=).
+
+    def initialize file, options = {}, zvfs = nil
+      init_internals file, options, zvfs
+
+      @tracefunc        = nil
+      @authorizer       = nil
+      @encoding         = nil
+      @busy_handler     = nil
+      @collations       = {}
+      @functions        = {}
+      @results_as_hash  = options[:results_as_hash]
+      @type_translation = options[:type_translation]
+
+      if block_given?
+        begin
+          yield self
+        ensure
+          close
+        end
+      end
+    end
+
     # A boolean that indicates whether rows in result sets should be returned
     # as hashes or not. By default, rows are returned as arrays.
     attr_accessor :results_as_hash


### PR DESCRIPTION
Deconstruct parameters in Ruby and just pass the right parameters to C.

(cherry picked from commit a4d5034703bfb48f9254da309b18a31913c13651)