### PR TITLE
Add SQLite3::Database#extended_result_codes=

### DIFF
--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -618,6 +618,22 @@ static VALUE set_busy_timeout(VALUE self, VALUE timeout)
   return self;
 }
 
+/* call-seq: db.extended_result_codes = true
+ *
+ * Enable extended result codes in SQLite.  These result codes allow for more
+ * detailed exception reporting, such a which type of constraint is violated.
+ */
+static VALUE set_extended_result_codes(VALUE self, VALUE enable)
+{
+  sqlite3RubyPtr ctx;
+  Data_Get_Struct(self, sqlite3Ruby, ctx);
+  REQUIRE_OPEN_DB(ctx);
+
+  CHECK(ctx->db, sqlite3_extended_result_codes(ctx->db, RTEST(enable) ? 1 : 0));
+
+  return self;
+}
+
 int rb_comparator_func(void * ctx, int a_len, const void * a, int b_len, const void * b)
 {
   VALUE comparator;
@@ -815,6 +831,7 @@ void init_sqlite3_database()
   rb_define_method(cSqlite3Database, "authorizer=", set_authorizer, 1);
   rb_define_method(cSqlite3Database, "busy_handler", busy_handler, -1);
   rb_define_method(cSqlite3Database, "busy_timeout=", set_busy_timeout, 1);
+  rb_define_method(cSqlite3Database, "extended_result_codes=", set_extended_result_codes, 1);
   rb_define_method(cSqlite3Database, "transaction_active?", transaction_active_p, 0);
   rb_define_private_method(cSqlite3Database, "db_filename", db_filename, 1);
 

--- a/ext/sqlite3/exception.c
+++ b/ext/sqlite3/exception.c
@@ -4,7 +4,9 @@ void rb_sqlite3_raise(sqlite3 * db, int status)
 {
   VALUE klass = Qnil;
 
-  switch(status) {
+  /* Consider only lower 8 bits, to work correctly when
+     extended result codes are enabled. */
+  switch(status & 0xff) {
     case SQLITE_OK:
       return;
       break;

--- a/test/test_database.rb
+++ b/test/test_database.rb
@@ -53,6 +53,16 @@ module SQLite3
       assert_equal 1, e.code
     end
 
+    def test_extended_error_code
+      db.extended_result_codes = true
+      db.execute 'CREATE TABLE "employees" ("token" integer NOT NULL)'
+      begin
+        db.execute 'INSERT INTO employees (token) VALUES (NULL)'
+      rescue SQLite3::ConstraintException => e
+      end
+      assert_equal 1299, e.code
+    end
+
     def test_bignum
       num = 4907021672125087844
       db.execute 'CREATE TABLE "employees" ("token" integer(8), "name" varchar(20) NOT NULL)'


### PR DESCRIPTION
If set to true, this enables extended result codes for the database,
which provide more information about separate failure types, such
as which type of constraint has been violated.

Support for this was added in SQLite 3.3.8, which was released over
10 years ago.  I didn't add extconf checks for this because it was
released so long ago, but if SQLite versions less than 3.3.8 are
supported, it's fairly easy to do that.  I'm not sure what behavior
is desired in that case.  We could either not define the method,
define it and have it always raise an exception, or define it and
have it do nothing.

(cherry picked from commit e4a145bfe80050cf0b1bb9957952af9b3c55a794)