### PR TITLE
Avoid deprecated row[0] call in get_first_value()

### DIFF
--- a/lib/sqlite3/database.rb
+++ b/lib/sqlite3/database.rb
@@ -344,7 +344,11 @@ Support for this will be removed in version 2.0.0.
     #
     # See also #get_first_row.
     def get_first_value( sql, *bind_vars )
-      execute( sql, *bind_vars ) { |row| return row[0] }
+      query( sql, bind_vars ) do |rs|
+        if (row = rs.next)
+          return @results_as_hash ? row[rs.columns[0]] : row[0]
+        end
+      end
       nil
     end
 

--- a/test/test_integration.rb
+++ b/test/test_integration.rb
@@ -359,9 +359,15 @@ class TC_Database_Integration < SQLite3::TestCase
   def test_get_first_value_no_bind_no_match
     result = @db.get_first_value( "select b, a from foo where a=100" )
     assert_nil result
+    @db.results_as_hash = true
+    result = @db.get_first_value( "select b, a from foo where a=100" )
+    assert_nil result
   end
 
   def test_get_first_value_no_bind_with_match
+    result = @db.get_first_value( "select b, a from foo where a=1" )
+    assert_equal "foo", result
+    @db.results_as_hash = true
     result = @db.get_first_value( "select b, a from foo where a=1" )
     assert_equal "foo", result
   end
@@ -369,9 +375,15 @@ class TC_Database_Integration < SQLite3::TestCase
   def test_get_first_value_with_bind_no_match
     result = @db.get_first_value( "select b, a from foo where a=?", 100 )
     assert_nil result
+    @db.results_as_hash = true
+    result = @db.get_first_value( "select b, a from foo where a=?", 100 )
+    assert_nil result
   end
 
   def test_get_first_value_with_bind_with_match
+    result = @db.get_first_value( "select b, a from foo where a=?", 1 )
+    assert_equal "foo", result
+    @db.results_as_hash = true
     result = @db.get_first_value( "select b, a from foo where a=?", 1 )
     assert_equal "foo", result
   end


### PR DESCRIPTION
If `@results_as_hash` is true, `row[0]` invokes
`ResultSet::HashWithTypesAndFields.[](key)`. Given a numeric key this
method will in turn call fields() which has been a deprecated API for 5
years.

The problem is that a library user with $VERBOSE=1 will receive a
useless deprecation warning:

/Library/Ruby/Gems/2.0.0/gems/sqlite3-1.3.12/lib/sqlite3/resultset.rb:65
:in `[]' is calling SQLite3::ResultSet::HashWithTypesAndFields#fields.
This method will be removed in sqlite3 version 2.0.0, please call the
`columns` method on the SQLite3::ResultSet object that created this
object.

The library user cannot make sense of this message without reading the
sqlite3-ruby source code. If the user reads the source code he will
realize that there is nothing he can do about the warnings except for
not calling get_first_value() with @results_as_hash anymore.

Btw: the deprecation warning would be clearer if it explicitly stated
that you should not call `row[key]` with a numeric key if
@results_as_hash = true. Furthermore, the library user might have
difficulties in applying the adviced fix "call ResultSet.columns()" if
he used to call `Database.execute` as it won't give him any ResultSet.
As a consequence the user has to figure out that he instead needs
`Database.query` by himself.

This patch also adds some Unit tests to ensure that get_first_value()
behaves correctly for both
@results_as_hash = true or false.

(cherry picked from commit 183a08c4efe26d334473f87fa92b2a169e48c23e)