### PR TITLE
Add Constants::TextRep::DETERMINISTIC, mirroring SQLITE_DETERMINISTIC

### DIFF
--- a/lib/sqlite3/constants.rb
+++ b/lib/sqlite3/constants.rb
@@ -6,6 +6,7 @@ module SQLite3 ; module Constants
     UTF16BE = 3
     UTF16   = 4
     ANY     = 5
+    DETERMINISTIC = 0x800
   end
 
   module ColumnType


### PR DESCRIPTION
Can be used with create_function / define_function_with_flags to signal
to sqlite that the function's output is deterministic for a given input

(cherry picked from commit f41abcf49666ea385a2a63af2f5db90e05914731)