### PR TITLE
Don't mandate dl functions for the extention build

### DIFF
--- a/ext/sqlite3/extconf.rb
+++ b/ext/sqlite3/extconf.rb
@@ -29,6 +29,8 @@ if RbConfig::CONFIG["host_os"] =~ /darwin/
   end
 end
 
+have_library 'dl' # for static builds
+
 if with_config('sqlcipher')
   pkg_config("sqlcipher")
 else


### PR DESCRIPTION
Sqlite3-ruby doesn't use dl functions, nor does extconf compile sqlite3
sources, which possibly makes use of them.
So mandating dl functions in extconf is wrong and breaks the build on
Windows.

Fixes #250 .

This pertly reverts commit f4ffec281a2888c1e536662ac1ea740fd3f5433c.

(cherry picked from commit 9d9ed4bbb4160a7deb08537cc0987640ded98ce1)