### PR TITLE
The taint mechanism will be deprecated in Ruby 2.7

### DIFF
--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -213,16 +213,16 @@ VALUE sqlite3val2rb(sqlite3_value * val)
       return rb_float_new(sqlite3_value_double(val));
       break;
     case SQLITE_TEXT:
-      return rb_tainted_str_new2((const char *)sqlite3_value_text(val));
+      return rb_str_new2((const char *)sqlite3_value_text(val));
       break;
     case SQLITE_BLOB: {
       /* Sqlite warns calling sqlite3_value_bytes may invalidate pointer from sqlite3_value_blob,
          so we explicitly get the length before getting blob pointer.
-         Note that rb_str_new and rb_tainted_str_new apparently create string with ASCII-8BIT (BINARY) encoding,
+         Note that rb_str_new apparently create string with ASCII-8BIT (BINARY) encoding,
          which is what we want, as blobs are binary
        */
       int len = sqlite3_value_bytes(val);
-      return rb_tainted_str_new((const char *)sqlite3_value_blob(val), len);
+      return rb_str_new((const char *)sqlite3_value_blob(val), len);
       break;
     }
     case SQLITE_NULL:

--- a/ext/sqlite3/statement.c
+++ b/ext/sqlite3/statement.c
@@ -151,7 +151,7 @@ static VALUE step(VALUE self)
               break;
             case SQLITE_TEXT:
               {
-                VALUE str = rb_tainted_str_new(
+                VALUE str = rb_str_new(
                     (const char *)sqlite3_column_text(stmt, i),
                     (long)sqlite3_column_bytes(stmt, i)
                 );
@@ -163,7 +163,7 @@ static VALUE step(VALUE self)
               break;
             case SQLITE_BLOB:
               {
-                VALUE str = rb_tainted_str_new(
+                VALUE str = rb_str_new(
                     (const char *)sqlite3_column_blob(stmt, i),
                     (long)sqlite3_column_bytes(stmt, i)
                 );

--- a/test/test_integration_resultset.rb
+++ b/test/test_integration_resultset.rb
@@ -105,23 +105,6 @@ class TC_ResultSet < SQLite3::TestCase
     assert_equal hash[1], "foo"
   end
 
-  def test_tainted_results_as_hash
-    @db.results_as_hash = true
-    @result.reset( 1 )
-    row = @result.next
-    row.each do |_, v|
-      assert(v.tainted?) if String === v
-    end
-  end
-
-  def test_tainted_row_values
-    @result.reset( 1 )
-    row = @result.next
-    row.each do |v|
-      assert(v.tainted?) if String === v
-    end
-  end
-
   def test_each
     called = 0
     @result.reset( 1, 2 )

--- a/test/test_statement.rb
+++ b/test/test_statement.rb
@@ -198,11 +198,6 @@ module SQLite3
       assert_equal ['foo'], r
     end
 
-    def test_tainted
-      r = @stmt.step
-      assert r.first.tainted?
-    end
-
     def test_step_twice
       assert_not_nil @stmt.step
       assert !@stmt.done?


### PR DESCRIPTION
The Ruby core team decided to deprecate the taint mechanism in Ruby 2.7
and will remove that in Ruby 3.

https://bugs.ruby-lang.org/issues/16131
https://github.com/ruby/ruby/pull/2476

In Ruby 2.7, `Object#{taint,untaint,trust,untrust}` and related
functions in the C-API no longer have an effect (all objects are always
considered untainted), and are now warned deprecation message.

https://buildkite.com/rails/rails/builds/65054#5aa2db21-569d-4202-99cd-a8323cab583e/6-8
(cherry picked from commit 0894fba641890521403f54b0fe7645182b991035)