### PR TITLE
Fix Ruby 2.7 rb_check_safe_obj warnings

### DIFF
--- a/ext/sqlite3/database.c
+++ b/ext/sqlite3/database.c
@@ -40,11 +40,13 @@ static VALUE rb_sqlite3_open_v2(VALUE self, VALUE file, VALUE mode, VALUE zvfs)
 
   Data_Get_Struct(self, sqlite3Ruby, ctx);
 
+#if defined TAINTING_SUPPORT
 #if defined StringValueCStr
   StringValuePtr(file);
   rb_check_safe_obj(file);
 #else
   Check_SafeStr(file);
+#endif
 #endif
 
       status = sqlite3_open_v2(
@@ -761,11 +763,13 @@ static VALUE rb_sqlite3_open16(VALUE self, VALUE file)
 
   Data_Get_Struct(self, sqlite3Ruby, ctx);
 
+#if defined TAINTING_SUPPORT
 #if defined StringValueCStr
   StringValuePtr(file);
   rb_check_safe_obj(file);
 #else
   Check_SafeStr(file);
+#endif
 #endif
 
   status = sqlite3_open16(utf16_string_value_ptr(file), &ctx->db);

--- a/ext/sqlite3/extconf.rb
+++ b/ext/sqlite3/extconf.rb
@@ -49,6 +49,10 @@ if RbConfig::CONFIG["host_os"] =~ /mswin/
   $CFLAGS << ' -W3'
 end
 
+if RUBY_VERSION < '2.7'
+  $CFLAGS << ' -DTAINTING_SUPPORT'
+end
+
 # enable column metadata
 $CFLAGS << ' -DSQLITE_ENABLE_COLUMN_METADATA=1'
 


### PR DESCRIPTION
(cherry picked from commit deb56f9a039fa713dad8c31af2fe5ea8e5ed0722)